### PR TITLE
Derive useful traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ pub trait Relation: OSMObjBase {
     fn members<'a>(&'a self) -> Box<dyn ExactSizeIterator<Item=(OSMObjectType, ObjId, &'a str)>+'a>;
 }
 
-#[derive(Clone,PartialEq,Eq,PartialOrd,Ord)]
+#[derive(Copy,Clone,PartialEq,Eq,PartialOrd,Ord)]
 pub enum OSMObjectType {
     Node,
     Way,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub type Lat = f32;
 /// Longitude
 pub type Lon = f32;
 
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum TimestampFormat {
     ISOString(String),
     EpochNunber(i64),
@@ -63,7 +63,7 @@ impl fmt::Display for TimestampFormat {
 }
 
 /// The basic metadata fields all OSM objects share
-pub trait OSMObjBase: PartialEq+Debug {
+pub trait OSMObjBase: PartialEq+Debug+Clone {
 
     fn id(&self) -> ObjId;
     fn set_id(&mut self, val: impl Into<ObjId>);

--- a/src/obj_types/rc_types.rs
+++ b/src/obj_types/rc_types.rs
@@ -22,7 +22,7 @@ macro_rules! func_call_inner_set {
 }
 
 
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct RcNode {
     pub(crate) _id: ObjId,
     pub(crate) _version: Option<u32>,
@@ -37,7 +37,7 @@ pub struct RcNode {
 }
 
 
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct RcWay {
     pub(crate) _id: ObjId,
     pub(crate) _version: Option<u32>,
@@ -51,7 +51,7 @@ pub struct RcWay {
     pub(crate) _nodes: Vec<ObjId>,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct RcRelation {
     pub(crate) _id: ObjId,
     pub(crate) _version: Option<u32>,
@@ -65,7 +65,7 @@ pub struct RcRelation {
     pub(crate) _members: Vec<(char, ObjId, Rc<str>)>,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum RcOSMObj {
     Node(RcNode),
     Way(RcWay),

--- a/src/obj_types/string_types.rs
+++ b/src/obj_types/string_types.rs
@@ -20,7 +20,7 @@ macro_rules! func_call_inner_set {
     )
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct StringNode {
     pub(crate) _id: ObjId,
     pub(crate) _version: Option<u32>,
@@ -35,7 +35,7 @@ pub struct StringNode {
 }
 
 
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct StringWay {
     pub(crate) _id: ObjId,
     pub(crate) _version: Option<u32>,
@@ -49,7 +49,7 @@ pub struct StringWay {
     pub(crate) _nodes: Vec<ObjId>,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct StringRelation {
     pub(crate) _id: ObjId,
     pub(crate) _version: Option<u32>,
@@ -63,7 +63,7 @@ pub struct StringRelation {
     pub(crate) _members: Vec<(char, ObjId, String)>,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum StringOSMObj {
     Node(StringNode),
     Way(StringWay),


### PR DESCRIPTION
Hi.  I liked your library and have used it with some success.

However, I found it it a bit awkward that, for example, `OSMObjectType` was not `Copy`, which it seems like it should be.  While I was there I thought the OSM object types should be `Clone` too so I added those derives.

Thanks,
Ian.