### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ chrono = "0.4.9"
 separator = "0.4.1"
 derive_builder = "0.10.2"
 quick-xml = "0.22.0"
-bzip2 = "0.4"
+bzip2 = "0.4.4"
 anyhow = "1.0"
 
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Updates bzip dependency to the patch version of 0.4.4

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0004.html)
[fix](https://github.com/alexcrichton/bzip2-rs/pull/86)